### PR TITLE
transferred lame-specific parameters into lame controller manager

### DIFF
--- a/Maim/Source/LameControllerManager.h
+++ b/Maim/Source/LameControllerManager.h
@@ -15,21 +15,48 @@
 
 #include "LameController.h"
 
-class LameControllerManager
+#define NUM_REASSIGNMENT_BANDS 20
+
+class LameControllerManager : public juce::AudioProcessorValueTreeState::Listener
 {
 public:
-    LameControllerManager(int samplerate, int initialBitrate, int samplesPerBlock);
+    LameControllerManager(int samplerate,
+                          int initialBitrate,
+                          int samplesPerBlock,
+                          juce::AudioProcessorValueTreeState& parameters);
     ~LameControllerManager();
 
     void changeBitrate(int newBitrate);
     void processBlock(juce::AudioBuffer<float>& buffer);
     
-    void updateParameters(juce::AudioProcessorValueTreeState& parameters,
-                          std::array<juce::AudioParameterInt*, 20>* bandReassignmentParameters,
-                          bool updateOffController=false);
+    void updateParameters(bool updateOffController=false);
     int getBitrate();
     
+    static constexpr std::array<int, 17> bitrates {
+        8,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+        80,
+        96,
+        112,
+        128,
+        160,
+        192,
+        224,
+        256,
+        320
+    };
+
+    
 private:
+    std::atomic<bool> parametersNeedUpdating;
+    void parameterChanged (const juce::String &parameterID, float newValue) override;
+    
     bool wantingToSwitch;
     int currentBitrate;
     const int samplerate;
@@ -41,4 +68,8 @@ private:
     std::array<LameController, 2> controllers;
     LameController* currentController;
     LameController* offController;
+    
+    std::array<juce::AudioParameterInt*, 20> bandReassignmentParameters;
+    juce::AudioProcessorValueTreeState& parameters;
+    
 };

--- a/Maim/Source/PluginProcessor.h
+++ b/Maim/Source/PluginProcessor.h
@@ -16,7 +16,6 @@
 #include "LameControllerManager.h"
 
 //==============================================================================
-#define NUM_REASSIGNMENT_BANDS 20
 
 juce::AudioProcessorValueTreeState::ParameterLayout makeParameters();
 
@@ -76,30 +75,9 @@ private:
     juce::AudioProcessorValueTreeState parameters;
     
     std::unique_ptr<LameControllerManager> lameControllerManager;
-    
-    std::array<juce::AudioParameterInt*, 20> bandReassignmentParameters;
-    
+        
     std::array<juce::IIRFilter, 2> postFilter;
     
-    const std::array<int, 17> bitrates {
-        8,
-        16,
-        24,
-        32,
-        40,
-        48,
-        56,
-        64,
-        80,
-        96,
-        112,
-        128,
-        160,
-        192,
-        224,
-        256,
-        320
-    };
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MaimAudioProcessor)
 };


### PR DESCRIPTION
resolving #6 and the problem with the bitrate squeeze param went away.