### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/cmake_test.yml
+++ b/.github/workflows/cmake_test.yml
@@ -101,9 +101,9 @@ jobs:
       run: brew install ninja osxutils
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
-        submodules: true # Get JUCE populated
+        submodules: recursive # Get JUCE populated
     - name: get msvc (windows)
       if: ${{ matrix.name == 'Windows' }}
       uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
CI currently fails because clap-juce-extensions has it's own submodules that aren't being populated. This PR attempts to fix this by updating the action + parameters.

For reference, here's the [context](https://github.com/ArdenButterfield/Maim/pull/58#issuecomment-2255392530).