### PR TITLE
chore: hide "made with juce" popup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ target_compile_definitions(SharedCode
         JUCE_VST3_CAN_REPLACE_VST2=0
 
         # Uncomment if you are paying for a an Indie/Pro license or releasing under GPLv3
-        # JUCE_DISPLAY_SPLASH_SCREEN=0
+        JUCE_DISPLAY_SPLASH_SCREEN=0
 
         # lets the app known if we're Debug or Release
         CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"


### PR DESCRIPTION
Simple change that hides JUCE's splash on startup. Since the plugin is released under GPLv3 license, it can be safely done.